### PR TITLE
Move ashtray under /obj/item/storage.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -47832,7 +47832,7 @@
 /area/blueshield)
 "cdR" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = -4;
 	pixel_y = -4
 	},
@@ -91220,7 +91220,7 @@
 /area/medical/cmo)
 "dVx" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -45764,7 +45764,7 @@
 	})
 "bUX" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = -4;
 	pixel_y = -4
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -190,7 +190,7 @@
 /area/derelict/bridge)
 "aA" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -727,7 +727,7 @@
 /area/derelict/bridge)
 "bI" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = 6;
 	pixel_y = 3
 	},
@@ -853,7 +853,7 @@
 /area/derelict/bridge)
 "bY" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -909,7 +909,7 @@
 /area/derelict/bridge)
 "cg" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -1423,7 +1423,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -2889,7 +2889,7 @@
 	})
 "gg" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -2969,7 +2969,7 @@
 /area/derelict/crew_quarters)
 "gp" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -3125,7 +3125,7 @@
 	})
 "gE" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -6054,7 +6054,7 @@
 	})
 "mM" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -6088,7 +6088,7 @@
 	})
 "mP" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -6534,7 +6534,7 @@
 	name = "Derelict Annex"
 	})
 "nQ" = (
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -6611,7 +6611,7 @@
 /area/derelict/crew_quarters)
 "nX" = (
 /obj/structure/table,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -7891,7 +7891,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel,
 /area/derelict/arrival)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -3436,7 +3436,7 @@
 /area/security/brig)
 "alp" = (
 /obj/structure/table,
-/obj/item/ashtray/bronze{
+/obj/item/storage/ashtray/bronze{
 	pixel_x = -1;
 	pixel_y = 1
 	},
@@ -12803,7 +12803,7 @@
 /area/crew_quarters/courtroom)
 "aEm" = (
 /obj/structure/table/wood/poker,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -13424,7 +13424,7 @@
 	pixel_y = 8
 	},
 /obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /obj/item/radio/intercom/department/security{
 	pixel_x = 28
 	},
@@ -13559,7 +13559,7 @@
 "aFV" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes,
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -20721,7 +20721,7 @@
 /area/crew_quarters/dorms)
 "aWD" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/dorms)
 "aWE" = (
@@ -26987,7 +26987,7 @@
 /area/chapel/main)
 "bjK" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze{
+/obj/item/storage/ashtray/bronze{
 	pixel_x = -1;
 	pixel_y = 1
 	},
@@ -54670,7 +54670,7 @@
 /area/ntrep)
 "coX" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = -4;
 	pixel_y = -4
 	},
@@ -64401,7 +64401,7 @@
 /area/maintenance/aft)
 "cIo" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze{
+/obj/item/storage/ashtray/bronze{
 	pixel_x = -1;
 	pixel_y = 1
 	},

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -492,17 +492,11 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/mine/living_quarters)
 "bp" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "purple"
+	},
 /area/mine/eva)
 "bq" = (
 /turf/simulated/wall,
@@ -523,36 +517,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/mine/living_quarters)
-"bs" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
 "bt" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/mine/eva)
 "bu" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
 /area/mine/eva)
 "bv" = (
 /obj/machinery/light/small{
@@ -567,13 +544,10 @@
 /obj/machinery/computer/shuttle/mining{
 	req_access = null
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "bx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -632,13 +606,10 @@
 "bC" = (
 /obj/structure/closet/crate,
 /obj/item/dice/d4,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "bD" = (
 /obj/machinery/camera{
@@ -653,18 +624,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "bE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
@@ -681,7 +646,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
 /area/mine/eva)
 "bF" = (
 /obj/effect/spawner/window,
@@ -691,21 +659,21 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/effect/baseturf_helper/lava_land/surface,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/mine/eva)
 "bH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "bI" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplecorner"
+	},
 /area/mine/eva)
 "bJ" = (
 /obj/effect/spawner/window/reinforced,
@@ -718,16 +686,16 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "mining";
 	pixel_y = 25;
 	tag_exterior_door = "mining_outer";
 	tag_interior_door = "mining_inner"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
 /area/mine/eva)
 "bL" = (
 /obj/machinery/door/airlock/security/glass{
@@ -786,10 +754,10 @@
 /area/shuttle/siberia)
 "bP" = (
 /obj/item/radio/beacon,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "bQ" = (
 /obj/structure/cable{
@@ -810,11 +778,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "bS" = (
 /obj/structure/cable{
@@ -834,8 +801,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplecorner"
+	},
 /area/mine/production)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -857,8 +825,9 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplecorner"
+	},
 /area/mine/eva)
 "bX" = (
 /obj/machinery/access_button{
@@ -870,11 +839,10 @@
 	pixel_y = 25;
 	req_access_txt = null
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "bY" = (
 /turf/simulated/floor/plasteel,
@@ -1016,13 +984,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "ck" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "cl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1041,13 +1006,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "cn" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "co" = (
 /obj/machinery/power/apc{
@@ -1056,29 +1018,28 @@
 	pixel_y = -23
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
+	},
 /area/mine/eva)
 "cp" = (
 /obj/machinery/suit_storage_unit/lavaland,
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "cq" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "cr" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "cs" = (
 /obj/structure/cable{
@@ -1087,19 +1048,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "ct" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cu" = (
 /obj/item/pickaxe,
@@ -1113,25 +1071,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/camera{
 	c_tag = "Shuttle Docking Foyer North";
 	dir = 8;
 	network = list("Mining Outpost")
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/mine/production)
 "cx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cy" = (
 /obj/effect/baseturf_helper/lava_land/surface,
@@ -1177,13 +1134,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1199,11 +1153,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cG" = (
 /obj/effect/spawner/window/reinforced,
@@ -1222,22 +1175,19 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cJ" = (
 /obj/machinery/door/airlock{
@@ -1260,14 +1210,10 @@
 /area/mine/living_quarters)
 "cN" = (
 /obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cO" = (
 /obj/machinery/light/small{
@@ -1365,23 +1311,17 @@
 	pixel_y = 23
 	},
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/simulated/floor/plasteel/white{
+	dir = 9;
+	icon_state = "whiteblue"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
 /area/mine/living_quarters)
 "dc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/simulated/floor/plasteel/white{
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
 /area/mine/living_quarters)
 "dd" = (
 /obj/structure/extinguisher_cabinet{
@@ -1392,13 +1332,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "de" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/simulated/floor/plasteel/white{
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
 /area/mine/living_quarters)
 "df" = (
 /obj/structure/table,
@@ -1409,14 +1346,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/simulated/floor/plasteel/white{
+	dir = 5;
+	icon_state = "whiteblue"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/simulated/floor/plasteel/white,
 /area/mine/living_quarters)
 "dg" = (
 /obj/machinery/alarm{
@@ -1459,11 +1392,10 @@
 /area/mine/maintenance)
 "dl" = (
 /obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "dm" = (
 /obj/effect/turf_decal/loading_area,
@@ -1516,11 +1448,10 @@
 "dt" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/turf/simulated/floor/plasteel/white{
+	dir = 4;
+	icon_state = "whiteblue"
 	},
-/turf/simulated/floor/plasteel/white,
 /area/mine/living_quarters)
 "du" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1530,13 +1461,10 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "dv" = (
 /obj/machinery/light{
@@ -1546,16 +1474,15 @@
 	pixel_x = 30;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/camera{
 	c_tag = "Shuttle Docking Foyer South";
 	dir = 8;
 	network = list("Mining Outpost")
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/mine/production)
 "dw" = (
 /obj/structure/closet/crate{
@@ -1577,12 +1504,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/baseturf_helper/lava_land/surface,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
 /area/mine/production)
 "dz" = (
 /obj/machinery/camera{
@@ -1603,11 +1529,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "dB" = (
 /obj/structure/closet/crate/freezer,
@@ -1638,7 +1563,10 @@
 	dir = 1;
 	network = list("Mining Outpost")
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel/white{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
 /area/mine/living_quarters)
 "dC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1701,14 +1629,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dK" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplecorner"
+	},
 /area/mine/production)
 "dL" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "dM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -1719,11 +1648,10 @@
 	id = "mining_internal";
 	name = "mining conveyor"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "dO" = (
 /obj/machinery/conveyor{
@@ -1771,23 +1699,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "dU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "dV" = (
 /obj/effect/spawner/window,
@@ -1798,10 +1723,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "dY" = (
 /obj/machinery/door/airlock/external{
@@ -1816,44 +1741,31 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
-"dZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
 "ea" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ec" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway East";
 	network = list("Mining Outpost")
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ed" = (
 /obj/machinery/camera{
@@ -1864,17 +1776,18 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ee" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplecorner"
+	},
 /area/mine/living_quarters)
 "ef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eg" = (
 /obj/machinery/power/apc{
@@ -1899,23 +1812,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "ej" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "ek" = (
 /obj/machinery/light{
@@ -1924,11 +1833,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "el" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -1954,11 +1862,11 @@
 /turf/simulated/wall,
 /area/mine/production)
 "eo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
+	},
 /area/mine/eva)
 "ep" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2025,10 +1933,10 @@
 /area/mine/living_quarters)
 "ew" = (
 /obj/structure/ore_box,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "ex" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -2056,11 +1964,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2072,13 +1979,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eA" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -2106,11 +2010,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eC" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -2133,23 +2036,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eF" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -2165,13 +2064,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2183,36 +2079,32 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplecorner"
+	},
 /area/mine/production)
 "eJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/structure/ore_box,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
 /area/mine/production)
 "eK" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "purple"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplecorner"
+	},
 /area/mine/living_quarters)
 "eM" = (
 /obj/machinery/light,
@@ -2231,11 +2123,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2264,10 +2154,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -2278,16 +2168,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eV" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eW" = (
 /turf/simulated/floor/plasteel,
@@ -2309,30 +2199,27 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "eZ" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "fa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fb" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
 /area/mine/production)
 "fc" = (
 /obj/machinery/alarm{
@@ -2342,13 +2229,11 @@
 /area/mine/living_quarters)
 "fd" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
 /area/mine/production)
 "fe" = (
 /obj/structure/bed,
@@ -2384,14 +2269,12 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fj" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
 /area/mine/production)
 "fk" = (
 /turf/simulated/floor/plasteel,
@@ -2427,16 +2310,10 @@
 /area/mine/production)
 "fo" = (
 /obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2459,30 +2336,27 @@
 	pixel_x = -5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fu" = (
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
+	},
 /area/mine/living_quarters)
 "fv" = (
 /obj/machinery/camera{
@@ -2494,60 +2368,45 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fx" = (
 /obj/machinery/vending/snack,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fz" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fB" = (
 /obj/structure/lattice/catwalk,
@@ -2558,31 +2417,24 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fD" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fF" = (
 /obj/item/radio/intercom{
@@ -2593,11 +2445,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fG" = (
 /obj/machinery/camera{
@@ -2608,10 +2459,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fH" = (
 /obj/machinery/door/airlock{
@@ -2625,11 +2476,9 @@
 /area/mine/living_quarters)
 "fI" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fJ" = (
 /obj/machinery/door/airlock/titanium{
@@ -2661,30 +2510,16 @@
 "fK" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fL" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"fM" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "brown"
 	},
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2734,11 +2569,9 @@
 /area/lavaland/surface/outdoors)
 "fU" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fV" = (
 /turf/simulated/wall/indestructible/boss/see_through,
@@ -2750,24 +2583,18 @@
 /area/lavaland/surface/outdoors)
 "fX" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fZ" = (
 /obj/structure/chair{
@@ -2776,11 +2603,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ga" = (
 /obj/structure/table,
@@ -2795,11 +2620,9 @@
 /obj/item/reagent_containers/food/drinks/cans/beer{
 	pixel_x = -8
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gb" = (
 /obj/structure/chair{
@@ -2808,11 +2631,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gc" = (
 /obj/machinery/door/window/southleft,
@@ -2844,20 +2665,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gg" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gh" = (
 /obj/item/radio/intercom{
@@ -2865,11 +2682,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gi" = (
 /obj/machinery/camera{
@@ -2881,12 +2696,10 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "gj" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -2917,33 +2730,27 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gm" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gn" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "go" = (
 /obj/structure/stone_tile/block,
@@ -2951,19 +2758,19 @@
 /area/lavaland/surface/outdoors)
 "gp" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gr" = (
 /obj/structure/stone_tile{
@@ -2995,10 +2802,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gu" = (
 /obj/machinery/door/airlock/external{
@@ -13087,7 +12894,7 @@ eL
 cM
 fs
 fk
-fM
+fU
 cR
 ab
 aj
@@ -14880,7 +14687,7 @@ cR
 de
 dD
 dR
-dZ
+ft
 es
 vZ
 cM
@@ -21807,7 +21614,7 @@ ai
 ab
 ab
 bg
-bs
+bt
 bY
 Ww
 bU

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4249,7 +4249,7 @@
 /area/syndicate_mothership)
 "pB" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	icon_state = "ashtray_half_gl"
 	},
 /obj/item/cigbutt/cigarbutt{
@@ -10168,7 +10168,7 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/shuttle/vox)
 "NC" = (
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /obj/structure/table,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)

--- a/_maps/map_files/shuttles/admin_admin.dmm
+++ b/_maps/map_files/shuttles/admin_admin.dmm
@@ -140,7 +140,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "ay" = (
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /obj/structure/table,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -1,17 +1,31 @@
-/obj/item/ashtray
+/obj/item/storage/ashtray
 	icon = 'icons/ashtray.dmi'
-	var/max_butts = 0
+	w_class = WEIGHT_CLASS_SMALL
+	can_hold = list(/obj/item/cigbutt, /obj/item/clothing/mask/cigarette)
+	allow_quick_empty = TRUE
+	allow_quick_gather = FALSE
+
+	// No generic container insertion messages/sounds.
+	silent = TRUE
+	use_sound = null
+
 	var/icon_half = ""
 	var/icon_full = ""
 
-/obj/item/ashtray/Initialize(mapload)
+/obj/item/storage/ashtray/Initialize(mapload)
 	. = ..()
 	pixel_y = rand(-5, 5)
 	pixel_x = rand(-6, 6)
 
-/obj/item/ashtray/attackby(obj/item/I, mob/user, params)
+/obj/item/storage/ashtray/attack_self(mob/user)
+	// We want allow_quick_empty to enable disposal dumping
+	// but don't want to accidentally dump ashtray contents
+	// on the floor.
+	return
+
+/obj/item/storage/ashtray/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/cigbutt) || istype(I, /obj/item/clothing/mask/cigarette) || istype(I, /obj/item/match))
-		if(contents.len >= max_butts)
+		if(contents.len >= storage_slots)
 			to_chat(user, "This ashtray is full.")
 			return
 		if(!user.unEquip(I))
@@ -34,61 +48,65 @@
 	else
 		return ..()
 
-/obj/item/ashtray/update_icon()
-	if(contents.len == max_butts)
+/obj/item/storage/ashtray/examine(mob/user)
+	. = ..()
+	if(contents.len == storage_slots)
+		. += " It's stuffed full."
+	else if(contents.len > storage_slots * 0.5)
+		. += " It's half-filled."
+
+/obj/item/storage/ashtray/update_icon()
+	if(contents.len == storage_slots)
 		icon_state = icon_full
-		desc = initial(desc) + " It's stuffed full."
-	else if(contents.len > max_butts * 0.5)
+	else if(contents.len > storage_slots * 0.5)
 		icon_state = icon_half
-		desc = initial(desc) + " It's half-filled."
 	else
 		icon_state = initial(icon_state)
-		desc = initial(desc)
 
-/obj/item/ashtray/deconstruct()
+/obj/item/storage/ashtray/deconstruct()
 	empty_tray()
 	qdel(src)
 
-/obj/item/ashtray/proc/empty_tray()
+/obj/item/storage/ashtray/proc/empty_tray()
 	for(var/obj/item/I in contents)
 		I.forceMove(loc)
 	update_icon()
 
-/obj/item/ashtray/throw_impact(atom/hit_atom)
+/obj/item/storage/ashtray/throw_impact(atom/hit_atom)
 	if(contents.len)
 		visible_message("<span class='warning'>[src] slams into [hit_atom] spilling its contents!</span>")
 	empty_tray()
 	return ..()
 
-/obj/item/ashtray/plastic
+/obj/item/storage/ashtray/plastic
 	name = "plastic ashtray"
 	desc = "Cheap plastic ashtray."
 	icon_state = "ashtray_bl"
 	icon_half  = "ashtray_half_bl"
 	icon_full  = "ashtray_full_bl"
-	max_butts = 8
+	storage_slots = 8
 	max_integrity = 8
 	materials = list(MAT_METAL=30, MAT_GLASS=30)
 	throwforce = 3
 
-/obj/item/ashtray/bronze
+/obj/item/storage/ashtray/bronze
 	name = "bronze ashtray"
 	desc = "Massive bronze ashtray."
 	icon_state = "ashtray_br"
 	icon_half  = "ashtray_half_br"
 	icon_full  = "ashtray_full_br"
-	max_butts = 16
+	storage_slots = 16
 	max_integrity = 16
 	materials = list(MAT_METAL=80)
 	throwforce = 10
 
-/obj/item/ashtray/glass
+/obj/item/storage/ashtray/glass
 	name = "glass ashtray"
 	desc = "Glass ashtray. Looks fragile."
 	icon_state = "ashtray_gl"
 	icon_half  = "ashtray_half_gl"
 	icon_full  = "ashtray_full_gl"
-	max_butts = 12
+	storage_slots = 12
 	max_integrity = 12
 	materials = list(MAT_GLASS=60)
 	throwforce = 6

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -488,7 +488,7 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/empty), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
 	new /datum/stack_recipe("plastic crate", /obj/structure/closet/crate/plastic, 10, one_per_turf = 1, on_floor = 1), \
-	new /datum/stack_recipe("plastic ashtray", /obj/item/ashtray/plastic, 2, one_per_turf = 1, on_floor = 1), \
+	new /datum/stack_recipe("plastic ashtray", /obj/item/storage/ashtray/plastic, 2, one_per_turf = 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic fork", /obj/item/kitchen/utensil/pfork, 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic spoon", /obj/item/kitchen/utensil/pspoon, 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic spork", /obj/item/kitchen/utensil/pspork, 1, on_floor = 1), \

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -22,6 +22,10 @@
 	create_reagents(volume)
 	noz = make_noz()
 
+/obj/item/watertank/Destroy()
+	QDEL_NULL(noz)
+	return ..()
+
 /obj/item/watertank/ui_action_click()
 	toggle_mister()
 
@@ -131,6 +135,10 @@
 		reagents = tank.reagents	//This mister is really just a proxy for the tank's reagents
 		loc = tank
 	return
+
+/obj/item/reagent_containers/spray/mister/Destroy()
+	tank = null
+	return ..()
 
 /obj/item/reagent_containers/spray/mister/dropped(mob/user as mob)
 	..()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -301,10 +301,10 @@
 	disabled = TRUE
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
+	addtimer(CALLBACK(src, .proc/reboot), disable_time SECONDS)
 	if(istype(loc, /mob/living/carbon/human))
 		var/mob/living/carbon/human/C = loc
 		C.update_inv_wear_suit()
-		addtimer(CALLBACK(src, .proc/reboot), disable_time SECONDS)
 
 /obj/item/clothing/suit/armor/reactive/proc/reboot()
 	disabled = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

The point of this PR was to allow ashtrays to be emptied by using them on disposal chutes. I decided to go with a type change here because 1) it means no snowflake casing for ashtrays in the disposal chutes code, and 2)  because /obj/item/storage has the functionality needed to move items over without rewriting that implementation.

I tried to keep the behavior as close to as how ashtrays work right now. The only thing that's remarkably different is that the inventory of the ashtray can be opened like other containers, but I don't see any huge issue with that.

## Why It's Good For The Game

Easier to empty ashtrays.

## Changelog
:cl:
add: Ashtrays can now be emptied in disposals chutes.
/:cl:
