### PR TITLE
Move inline job titles to defines.

### DIFF
--- a/code/__DEFINES/roles.dm
+++ b/code/__DEFINES/roles.dm
@@ -1,0 +1,80 @@
+// Roles centralizes the strings used in code for representing player roles,
+// which may be jobs or antag types or what-have-you.
+
+// Central Command
+#define ROLE_SOO				"Special Operations Officer"
+#define ROLE_NNO				"Nanotrasen Navy Officer"
+
+// Syndicate
+#define ROLE_SYNDI_OFFICER		"Syndicate Officer"
+
+// Solfed
+#define ROLE_SOLFED_GENERAL		"Solar Federation General"
+
+// ERT
+#define ROLE_ERT_LEAD			"Emergency Response Team Leader"
+#define ROLE_ERT_MEMBER			"Emergency Response Team Member"
+
+// Command
+#define ROLE_CAPTAIN			"Captain"
+#define ROLE_HOS				"Head of Security"
+#define ROLE_HOP				"Head of Personnel"
+#define ROLE_RD					"Research Director"
+#define ROLE_CMO				"Chief Medical Officer"
+#define ROLE_CE					"Chief Engineer"
+
+// Dignitaries
+#define ROLE_NTR				"Nanotrasen Representative"
+#define ROLE_BLUESHIELD			"Blueshield"
+#define ROLE_VIP				"VIP Guest"
+
+// Security
+#define ROLE_WARDEN				"Warden"
+#define ROLE_DETECTIVE			"Detective"
+#define ROLE_SEC_OFFICER		"Security"
+
+// Procedure
+#define ROLE_MAGISTRATE			"Magistrate"
+#define ROLE_IAA				"Internal Affairs Agent"
+
+// Engineering
+#define ROLE_ENGINEER			"Station Engineer"
+#define ROLE_LIFESUPPORT		"Life Support Specialist"
+#define ROLE_ATMOS				"Atmospheric Technician"  // Alternate atmos name
+
+// Medical
+#define ROLE_DOCTOR				"Medical Doctor"
+#define ROLE_PSYCH				"Psychiatrist"
+#define ROLE_CHEMIST			"Chemist"
+#define ROLE_VIROLOGIST			"Virologist"
+#define ROLE_PARAMEDIC			"Paramedic"
+#define ROLE_CORONER			"Coroner"
+
+// Supply
+#define ROLE_QM					"Quartermaster"
+#define ROLE_CARGOTECH			"Cargo Technician"
+#define ROLE_MINER				"Shaft Miner"
+
+// Science
+#define ROLE_SCIENTIST			"Scientist"
+#define ROLE_GENETICIST			"Geneticist"
+#define ROLE_ROBOTICIST			"Roboticist"
+
+// Service
+#define ROLE_ASSISTANT			"Assistant"
+#define ROLE_CLOWN				"Clown"
+#define ROLE_MIME				"Mime"
+#define ROLE_CHEF				"Chef"
+#define ROLE_BOTANIST			"Botanist"
+#define ROLE_JANITOR			"Janitor"
+#define ROLE_LIBRARIAN			"Librarian"
+#define ROLE_CHAPLAIN			"Chaplain"
+#define ROLE_BARBER				"Barber"
+
+// Synthetic
+#define ROLE_AI					"AI"
+#define ROLE_CYBORG				"Cyborg"
+
+// Miscellaneous
+#define ROLE_EXPLORER			"Explorer"
+

--- a/code/datums/cache/crew.dm
+++ b/code/datums/cache/crew.dm
@@ -26,7 +26,7 @@ GLOBAL_DATUM_INIT(crew_repository, /datum/repository/crew, new())
 		bold_jobs = list()
 		bold_jobs += GLOB.command_positions
 		bold_jobs += get_all_centcom_jobs()
-		bold_jobs += list("Nanotrasen Representative", "Blueshield", "Magistrate")
+		bold_jobs += list(ROLE_NTR, ROLE_BLUESHIELD, ROLE_MAGISTRATE)
 
 	for(var/thing in GLOB.human_list)
 		var/mob/living/carbon/human/H = thing

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -73,8 +73,23 @@ Made by Xhuis
 	required_players = 30
 	required_enemies = 2
 	recommended_enemies = 2
-	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Solar Federation General")
+	restricted_jobs = list(ROLE_AI, ROLE_CYBORG)
+	protected_jobs = list(
+		ROLE_BLUESHIELD,
+		ROLE_CAPTAIN,
+		ROLE_DETECTIVE,
+		ROLE_HOP,
+		ROLE_HOS,
+		ROLE_IAA,
+		ROLE_MAGISTRATE,
+		ROLE_NNO,
+		ROLE_NTR,
+		ROLE_SEC_OFFICER,
+		ROLE_SOLFED_GENERAL,
+		ROLE_SOO,
+		ROLE_SYNDI_OFFICER,
+		ROLE_WARDEN,
+	)
 
 /datum/game_mode/shadowling/announce()
 	to_chat(world, "<b>The current game mode is - Shadowling!</b>")


### PR DESCRIPTION
Just an example with one or two refactorings to demonstrate usage

This is a good idea because using inline strings is prone to typos. It also provides useful autocomplete in vscode for utilizing these job names in implementations.